### PR TITLE
Simplify hyperparameters to muDM and alpha

### DIFF
--- a/mock_generator/mock_generator.py
+++ b/mock_generator/mock_generator.py
@@ -83,11 +83,10 @@ def run_mock_simulation(
     process=None,
     alpha_s=-1.3,
     m_s_star=24.5,
+    logalpha: float = 0.1,
 ):
     beta_samp = np.random.rand(n_samples)**0.5
-    # alpha_sps = np.random.normal(loc=1.2, scale=0.2, size=n_samples)
-    # logalpha_sps_sample = np.log10(alpha_sps)
-    logalpha_sps_sample = np.random.normal(loc=0.1, scale=0.05, size=n_samples)  # Example logalpha_sps
+    logalpha_sps_sample = np.full(n_samples, logalpha)
     samples = generate_samples(n_samples, alpha_s=alpha_s, m_s_star=m_s_star)
 
     if process is None or process == 0:

--- a/plotting.py
+++ b/plotting.py
@@ -21,7 +21,7 @@ def plot_chain(chain: np.ndarray, fname: str = "chain_trace.png") -> None:
     fig, ax = plt.subplots(figsize=(6, 4))
     ax.plot(chain[:, :, 0], alpha=0.3)
     ax.set_xlabel("Step")
-    ax.set_ylabel(r"$\mu_0$")
+    ax.set_ylabel(r"$\mu_{DM}$")
     fig.tight_layout()
     # fig.savefig(fname)
     # plt.close(fig)

--- a/run_mcmc.py
+++ b/run_mcmc.py
@@ -44,8 +44,8 @@ def run_mcmc(
     nwalkers, nsteps:
         MCMC configuration.
     initial_guess:
-        Initial position of the walkers in parameter space.  Must have length 5
-        corresponding to ``(mu0, beta, sigmaDM, mu_alpha, sigma_alpha)``.
+        Initial position of the walkers in parameter space.  Must have length 2
+        corresponding to ``(muDM, alpha)``.
     backend_file:
         Filename or path for the HDF5 backend.  If a relative path is
         supplied, the file will be placed inside the ``chains`` directory.  The
@@ -83,9 +83,9 @@ def run_mcmc(
     # return sampler
 
 
-    ndim = 5
+    ndim = 2
     if initial_guess is None:
-        initial_guess = np.array([12.5, 2.0, 0.3, 0.1, 0.1])
+        initial_guess = np.array([12.5, 0.1])
 
     # === 使用 pathlib 构建路径 ===
     base_dir = Path(__file__).parent.resolve()


### PR DESCRIPTION
## Summary
- Reduce inference to two hyperparameters (muDM, alpha) without alpha scatter
- Fix sample generation to use constant alpha
- Update MCMC setup, main script, and plotting to match new parameterization

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894d0f8b6e8832db574d31b96df27e8