### PR TITLE
Centralize scatter configuration

### DIFF
--- a/compute_A_eta.py
+++ b/compute_A_eta.py
@@ -21,13 +21,13 @@ if __package__ is None or __package__ == "":
     from compute_norm_acc.mock_generator.lens_solver import solve_single_lens
     from compute_norm_acc.mock_generator.lens_model import LensModel
     from compute_norm_acc.utils import selection_function
-    from compute_norm_acc.config import OBS_SCATTER_MAG
+    from compute_norm_acc.config import SCATTER
 else:
     from .mock_generator.mass_sampler import generate_samples, MODEL_PARAMS
     from .mock_generator.lens_solver import solve_single_lens
     from .mock_generator.lens_model import LensModel
     from .utils import selection_function
-    from .config import OBS_SCATTER_MAG
+    from .config import SCATTER
 
 
 def sample_lens_population(n_samples, zl=0.3, zs=2.0):
@@ -159,7 +159,7 @@ def compute_A_eta(n_samples=5000, ms_points=15, m_lim=26.5, lens_file="lens_samp
 
     for j, alpha in enumerate(tqdm(alpha_grid, desc="alpha loop")):
         # logM_star = samples["logM_star_sps"] + alpha
-        logM_star = samples["logM_star_sps"] + alpha + np.random.normal(0, 0.01, size=n_samples)
+        logM_star = samples["logM_star_sps"] + alpha + np.random.normal(0, SCATTER.star, size=n_samples)
 
         mu1, mu2 = compute_magnifications(
             logM_star,
@@ -169,8 +169,8 @@ def compute_A_eta(n_samples=5000, ms_points=15, m_lim=26.5, lens_file="lens_samp
             samples["zl"],
             samples["zs"],
         )
-        sel1 = selection_function(mu1[:, None], m_lim, ms_grid[None, :], OBS_SCATTER_MAG)
-        sel2 = selection_function(mu2[:, None], m_lim, ms_grid[None, :], OBS_SCATTER_MAG)
+        sel1 = selection_function(mu1[:, None], m_lim, ms_grid[None, :], SCATTER.mag)
+        sel2 = selection_function(mu2[:, None], m_lim, ms_grid[None, :], SCATTER.mag)
         p_det = sel1 * sel2
         w_ms = np.trapz(p_det * pdf_ms[None, :], ms_grid, axis=1)
         w_static = w_ms

--- a/config.py
+++ b/config.py
@@ -1,8 +1,15 @@
 """Global configuration for simulation and inference parameters."""
 
-# Measurement scatter for observed quantities (dex or mag)
-OBS_SCATTER_STAR: float = 0.01
-OBS_SCATTER_MAG: float = 0.1
+from dataclasses import dataclass
 
-# 0.2/40=0.005
 
+@dataclass(frozen=True)
+class ScatterConfig:
+    """Measurement scatter settings for observables."""
+
+    star: float = 0.01  # Scatter on log stellar mass [dex]
+    mag: float = 0.1    # Scatter on observed magnitudes [mag]
+
+
+# Global scatter configuration used throughout the package
+SCATTER = ScatterConfig()

--- a/likelihood.py
+++ b/likelihood.py
@@ -24,7 +24,7 @@ from .utils import mag_likelihood, selection_function
 from .cached_A import cached_A_interp
 from .make_tabulate.make_tabulate import LensGrid, tabulate_likelihood_grids
 from .mock_generator.mass_sampler import MODEL_PARAMS
-from .config import OBS_SCATTER_STAR, OBS_SCATTER_MAG
+from .config import SCATTER
 
 
 # Parameters of the generative model (default: deVauc) used for sizes
@@ -68,7 +68,7 @@ def precompute_grids(
     """
 
     if sigma_m is None:
-        sigma_m = OBS_SCATTER_MAG
+        sigma_m = SCATTER.mag
 
     return tabulate_likelihood_grids(
         mock_observed_data,
@@ -138,9 +138,9 @@ def _single_lens_likelihood(
         scale=SIGMA_DM,
     )
 
-    scatter_Mstar = OBS_SCATTER_STAR  # Measurement scatter
+    scatter_Mstar = SCATTER.star  # Measurement scatter
 
-    # Stellar-mass likelihood (measurement scatter of 0.1 dex)
+    # Stellar-mass likelihood with measurement scatter on log stellar mass
     p_Mstar = norm.pdf(
         logM_sps_obs,
         loc=logM_star - alpha,

--- a/main.py
+++ b/main.py
@@ -8,19 +8,12 @@ from .mock_generator.mock_generator import run_mock_simulation
 from .likelihood import precompute_grids
 from .run_mcmc import run_mcmc
 from .plotting import plot_chain
-from . import config
+from .config import SCATTER
 import matplotlib.pyplot as plt
 import matplotlib
 matplotlib.use("TkAgg")  # 或者 Qt5Agg, MacOSX
 
-
-
-# scatter_Mstar = 0.01
-
 def main() -> None:
-    scatter = 0.1  # Global measurement scatter (dex or mag)
-    config.OBS_SCATTER_STAR = 0.01
-
     # Generate mock data for samples with fixed logalpha
     mock_lens_data, mock_observed_data = run_mock_simulation(500, logalpha=0.1)
     logM_sps_obs = mock_observed_data["logM_star_sps_observed"].values
@@ -29,7 +22,7 @@ def main() -> None:
 
     # Precompute grids on halo mass
     logMh_grid = np.linspace(11.5, 14.0, 100)
-    grids = precompute_grids(mock_observed_data, logMh_grid, sigma_m=scatter)
+    grids = precompute_grids(mock_observed_data, logMh_grid, sigma_m=SCATTER.mag)
     nsteps = 5000
     # Run MCMC sampling for 10000 steps
     sampler = run_mcmc(

--- a/make_tabulate/make_tabulate.py
+++ b/make_tabulate/make_tabulate.py
@@ -22,6 +22,7 @@ from typing import Iterable, List
 import numpy as np
 import pandas as pd
 
+from ..config import SCATTER
 from ..mock_generator.lens_solver import (
     compute_detJ,
     solve_lens_parameters_from_obs,
@@ -69,7 +70,7 @@ def tabulate_likelihood_grids(
     logMh_grid: Iterable[float],
     zl: float = 0.3,
     zs: float = 2.0,
-    sigma_m: float = 0.1,
+    sigma_m: float = SCATTER.mag,
     m_lim: float = 26.5,
 ) -> List[LensGrid]:
     """Compute grids of lensing quantities required by the likelihood.

--- a/mock_generator/lens_properties.py
+++ b/mock_generator/lens_properties.py
@@ -1,7 +1,7 @@
 from .lens_solver import solve_single_lens
 from .lens_model import kpc_to_arcsec, LensModel
 from ..sl_cosmology import Dang
-from ..config import OBS_SCATTER_STAR, OBS_SCATTER_MAG
+from ..config import SCATTER
 import numpy as np
 
 # SPS PARAMETER
@@ -65,14 +65,13 @@ def observed_data(input_df, caustic=False, scatter_Mstar=None):
 
    # magnificationA, magnificationB = properties['magnificationA'], properties['magnificationB']
    
-   scatter_mag = OBS_SCATTER_MAG  # [mag] 源光度的散射
+   scatter_mag = SCATTER.mag  # [mag] 源光度的散射
    properties['scatter_mag'] = scatter_mag
    magnitude_observedA = m_s - 2.5 * np.log10(properties['magnificationA']) + np.random.normal(loc=0.0, scale=scatter_mag)
    magnitude_observedB = m_s - 2.5 * np.log10(properties['magnificationB']) + np.random.normal(loc=0.0, scale=scatter_mag)
 
    if scatter_Mstar is None:
-       scatter_Mstar = OBS_SCATTER_STAR  # [Msun] 源质量的散射
-   # scatter_Mstar = 0.1  # [Msun] 源质量的散射
+       scatter_Mstar = SCATTER.star  # [Msun] 源质量的散射
 
 
 


### PR DESCRIPTION
## Summary
- Define a `ScatterConfig` dataclass in `config` to hold distinct star and magnitude scatter values
- Reference scatter settings via `config.SCATTER` across modules and remove runtime overrides
- Ensure both star and magnitude scatter usage stay separated in simulation and likelihood code

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895957c5850832db6198655f2b5ee6e