### PR TITLE
Add beta weighting to likelihood calculations

### DIFF
--- a/likelihood.py
+++ b/likelihood.py
@@ -119,6 +119,7 @@ def _single_lens_likelihood(
     detJ = grid.detJ[mask]
     muA = grid.muA[mask]
     muB = grid.muB[mask]
+    beta_w = grid.beta[mask]
 
     # Marginalize over source magnitude
     selA_ms = selection_function(muA[None, :], grid.m_lim, MS_GRID[:, None], grid.sigma_m)
@@ -129,11 +130,11 @@ def _single_lens_likelihood(
         P_MS[:, None] * selA_ms * selB_ms * p_magA_ms * p_magB_ms, MS_GRID, axis=0
     )
 
-    const = detJ * integral_ms
-    
-    # beta_w = grid.beta[mask]                     # 仅用 β（或用 2*beta/(beta_max**2) 若有 beta_max）
-    # const  = np.abs(detJ) * beta_w * integral_ms # 之前只有 detJ*integral_ms
-    # Z = p_Msps_prior * p_Mstar * p_logRe * p_logMh * const
+    # Incorporate the weighting from the source-position ``beta``.  The
+    # ``beta`` values returned by :func:`solve_lens_parameters_from_obs` are
+    # normalised by the maximum caustic scale, so a uniform distribution of
+    # sources implies a probability density proportional to ``beta``.
+    const = np.abs(detJ) * beta_w * integral_ms
 
 
     # Halo–mass relation conditioned on the SPS-based stellar mass

--- a/make_tabulate/make_tabulate.py
+++ b/make_tabulate/make_tabulate.py
@@ -44,6 +44,9 @@ class LensGrid:
         Determinant of the Jacobian of the transformation.
     muA, muB:
         Magnifications of the two images.
+    beta:
+        Source-plane impact parameter (dimensionless) corresponding to each
+        halo-mass grid point.
     logRe:
         Observed effective radius used when generating the grid.
     m1_obs, m2_obs:
@@ -58,6 +61,7 @@ class LensGrid:
     detJ: np.ndarray
     muA: np.ndarray
     muB: np.ndarray
+    beta: np.ndarray
     logRe: float
     m1_obs: float
     m2_obs: float
@@ -111,10 +115,11 @@ def tabulate_likelihood_grids(
         detJ_list = []
         muA_list = []
         muB_list = []
+        beta_list = []
 
         for logMh in logMh_grid:
             try:
-                logM_star, _ = solve_lens_parameters_from_obs(
+                logM_star, beta = solve_lens_parameters_from_obs(
                     xA, xB, logRe, logMh, zl, zs
                 )
                 detJ = compute_detJ(xA, xB, logRe, logMh, zl, zs)
@@ -133,11 +138,13 @@ def tabulate_likelihood_grids(
                 detJ = 0.0
                 muA = np.nan
                 muB = np.nan
+                beta = np.nan
 
             logMstar_list.append(logM_star)
             detJ_list.append(detJ)
             muA_list.append(muA)
             muB_list.append(muB)
+            beta_list.append(beta)
 
         results.append(
             LensGrid(
@@ -146,6 +153,7 @@ def tabulate_likelihood_grids(
                 detJ=np.array(detJ_list),
                 muA=np.array(muA_list),
                 muB=np.array(muB_list),
+                beta=np.array(beta_list),
                 logRe=logRe,
                 m1_obs=m1_obs,
                 m2_obs=m2_obs,


### PR DESCRIPTION
## Summary
- Store source-plane impact parameter beta within `LensGrid` tables
- Use beta weight when building per-lens likelihood integrals

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896091d32f4832d8a11ea3c524efe6a